### PR TITLE
Fix server error for hero detail endpoint

### DIFF
--- a/mlbb_api/views.py
+++ b/mlbb_api/views.py
@@ -327,7 +327,6 @@ def hero_position(request):
         }, status=response.status_code)
 
 @api_view(['GET'])
-@api_view(['GET'])
 @api_availability_required
 def hero_detail(request, hero_id):
     url = f"{MLBB_URL}gms/source/2669606/2756564"


### PR DESCRIPTION
The hero detail endpoint previously encountered a server error. This update modifies the endpoint to ensure proper handling of requests, resolving the issue.

Fixes #37