### PR TITLE
Potential fix for code scanning alert no. 8: Information exposure through an exception

### DIFF
--- a/apps/mlbb_api/views.py
+++ b/apps/mlbb_api/views.py
@@ -506,13 +506,15 @@ class WinRateView(APIAvailabilityMixin, ErrorResponseMixin, APIView):
             wr_now_float = float(wr_now)
             wr_future_float = float(wr_future)
         except ValueError as e:
+            import logging
+            logging.error(f"Input validation error: {e}")
             return Response({
                 "status": "error",
                 "match_now": match_now,
                 "wr_now": wr_now,
                 "wr_future": wr_future,
                 "required_no_lose_matches": None,
-                "message": str(e) or "Invalid input. Ensure match-now is an integer and wr-now, wr-future are numeric values."
+                "message": "Invalid input. Ensure match-now is an integer and wr-now, wr-future are numeric values."
             }, status=status.HTTP_400_BAD_REQUEST)
 
         # Business logic validations


### PR DESCRIPTION
Potential fix for [https://github.com/ridwaanhall/api-mobilelegends/security/code-scanning/8](https://github.com/ridwaanhall/api-mobilelegends/security/code-scanning/8)

To fix the issue, the code should avoid exposing the exception message `str(e)` directly to the user. Instead, log the exception details on the server for debugging purposes and return a generic error message to the user. This ensures that sensitive information is not leaked while still allowing developers to diagnose issues.

**Steps to implement the fix:**
1. Replace the usage of `str(e)` in the response with a generic error message.
2. Log the exception details using a logging mechanism (e.g., Python's `logging` module).
3. Ensure that the user-facing error message does not reveal any internal details.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
