### PR TITLE
Change default API availability to true

### DIFF
--- a/MLBB/settings.py
+++ b/MLBB/settings.py
@@ -21,7 +21,7 @@ MLBB_URL = config('MLBB_URL')
 PROD_URL = config('PROD_URL')
 
 # API Availability Control
-IS_AVAILABLE = config('IS_AVAILABLE', default=False, cast=bool)
+IS_AVAILABLE = config('IS_AVAILABLE', default=True, cast=bool)
 
 SUPPORT_DETAILS = {
     'support_message': 'You can support us by donating from $1 USD (target: $500 USD) to help enhance API performance and handle high request volumes.',


### PR DESCRIPTION
Update the default value of the API availability setting to true, ensuring that the API and website are accessible by default. This change addresses the issue of the API and website not being available.

Fixes #43